### PR TITLE
Skip already minified files ( *.min.* )

### DIFF
--- a/lib/minify-js.mjs
+++ b/lib/minify-js.mjs
@@ -54,8 +54,9 @@ export function minifyFiles (inputPath, addSuffix, outputPath, inclusions) {
     })
   } else {
     getLogger().debug('Input path ', inputPath, ' is a file')
-
-    if (supportedExtensions.includes(path.extname(inputPath))) {
+    if (inputPath.includes(".min.")) {
+      getLogger().debug('Skipping file ', inputPath, " is already minified.")  
+    } else if (supportedExtensions.includes(path.extname(inputPath))) {
       if (inclusions.length === 0 || inclusions.some((regex) => regex.test(inputPath))) {
         minifyFile(inputPath, addSuffix, outputPath)
       } else {


### PR DESCRIPTION
not yet tested, but this should prevent recursive file minification:

script.js
script.min.js
script.min.min.js
...

